### PR TITLE
Feat/add input component

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,19 +1,19 @@
-import react from 'eslint-plugin-react';
-import typescriptEslint from '@typescript-eslint/eslint-plugin';
-import globals from 'globals';
-import tsParser from '@typescript-eslint/parser';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-import js from '@eslint/js';
-import { FlatCompat } from '@eslint/eslintrc';
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+import globals from 'globals'
+import react from 'eslint-plugin-react'
+import tsParser from '@typescript-eslint/parser'
+import typescriptEslint from '@typescript-eslint/eslint-plugin'
+import js from '@eslint/js'
+import { FlatCompat } from '@eslint/eslintrc'
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
 const compat = new FlatCompat({
   baseDirectory: __dirname,
   recommendedConfig: js.configs.recommended,
-  allConfig: js.configs.all
-});
+  allConfig: js.configs.all,
+})
 
 export default [
   {
@@ -21,8 +21,8 @@ export default [
       '**/node_modules/*',
       '**/dist/*',
       '**/.next/*',
-      'src/styles/globals.css'
-    ]
+      'src/styles/globals.css',
+    ],
   },
   ...compat.extends(
     'next/core-web-vitals',
@@ -41,56 +41,58 @@ export default [
     languageOptions: {
       globals: {
         ...globals.browser,
-        ...globals.node
+        ...globals.node,
       },
       parser: tsParser,
       ecmaVersion: 11,
       sourceType: 'module',
       parserOptions: {
         ecmaFeatures: {
-          jsx: true
-        }
-      }
+          jsx: true,
+        },
+      },
     },
     settings: {
       react: {
-        version: 'detect'
-      }
+        version: 'detect',
+      },
     },
     rules: {
-      "camelcase": "off",
-      "no-useless-constructor": "off",
-      "@typescript-eslint/no-explicit-any": "off",
-      "@typescript-eslint/no-namespace": "off",
-      "@typescript-eslint/no-non-null-assertion": "off",
-      "no-use-before-define": "off",
-      "sort-imports": [
-        "error",
-        { "ignoreCase": true, "ignoreDeclarationSort": true }
+      camelcase: 'off',
+      'no-useless-constructor': 'off',
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-namespace': 'off',
+      '@typescript-eslint/no-non-null-assertion': 'off',
+      'no-use-before-define': 'off',
+      '@typescript-eslint/no-empty-interface': 'off',
+      '@typescript-eslint/no-empty-object-type': 'off',
+      'sort-imports': [
+        'error',
+        { ignoreCase: true, ignoreDeclarationSort: true },
       ],
-      "import/order": [
-        "error",
+      'import/order': [
+        'error',
         {
-          "groups": [["external", "builtin"], "internal", ["sibling"]],
-          "pathGroups": [
+          groups: [['external', 'builtin'], 'internal', ['sibling']],
+          pathGroups: [
             {
-              "pattern": "react",
-              "group": "external",
-              "position": "before"
+              pattern: 'react',
+              group: 'external',
+              position: 'before',
             },
             {
-              "pattern": "@/**",
-              "group": "internal"
-            }
+              pattern: '@/**',
+              group: 'internal',
+            },
           ],
-          "pathGroupsExcludedImportTypes": ["internal", "react"],
-          "newlines-between": "always",
-          "alphabetize": {
-            "order": "desc",
-            "caseInsensitive": true
-          }
-        }
-      ]
-    }
-  }
-];
+          pathGroupsExcludedImportTypes: ['internal', 'react'],
+          'newlines-between': 'always',
+          alphabetize: {
+            order: 'desc',
+            caseInsensitive: true,
+          },
+        },
+      ],
+    },
+  },
+]

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "finance-manager-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@phosphor-icons/react": "^2.1.7",
         "next": "15.2.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -937,6 +938,19 @@
       "dev": true,
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@phosphor-icons/react": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.1.7.tgz",
+      "integrity": "sha512-g2e2eVAn1XG2a+LI09QU3IORLhnFNAFkNbo2iwbX6NOKSLOwvEMmTa7CgOzEbgNWR47z8i8kwjdvYZ5fkGx1mQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8",
+        "react-dom": ">= 16.8"
       }
     },
     "node_modules/@pkgr/core": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@phosphor-icons/react": "^2.1.7",
     "next": "15.2.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { Button, Logo } from '@/presentation/components/shared'
+import { FormExample } from '@/presentation/components/Example/Form'
 
 export default function Home() {
   return (
@@ -8,6 +9,8 @@ export default function Home() {
       <h1 className="text-primary-900 text-4xl">Testing</h1>
       <Logo />
       <Button>Testando</Button>
+
+      <FormExample />
     </div>
   )
 }

--- a/src/presentation/components/Example/Form.tsx
+++ b/src/presentation/components/Example/Form.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import React from 'react'
+
+import { User } from '@phosphor-icons/react'
+
+import {
+  Input,
+  InputDescription,
+  InputLabel,
+  InputPasswordStrength,
+  InputRoot,
+} from '../shared'
+
+export function FormExample() {
+  const [password, setPassword] = React.useState('')
+  const [username, setUsername] = React.useState('')
+
+  return (
+    <div className="m-auto flex w-[496px] flex-col">
+      <InputRoot>
+        <InputLabel htmlFor="password">Senha</InputLabel>
+
+        <Input
+          id="password"
+          type="password"
+          placeholder="Digite sua senha"
+          iconPosition="left"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+
+        <InputPasswordStrength value={password} />
+
+        <InputDescription>
+          A senha deve ter pelo menos 8 caracteres, incluindo letras maiúsculas,
+          minúsculas, números e caracteres especiais.
+        </InputDescription>
+      </InputRoot>
+
+      <InputRoot>
+        <InputLabel htmlFor="username">Nome de usuário</InputLabel>
+        <Input
+          id="username"
+          placeholder="Digite seu nome de usuário"
+          icon={<User className="text-muted-foreground h-4 w-4" />}
+          iconPosition="left"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+        />
+        <InputDescription>
+          Seu nome de usuário será visível para outros usuários.
+        </InputDescription>
+      </InputRoot>
+    </div>
+  )
+}

--- a/src/presentation/components/Example/Form.tsx
+++ b/src/presentation/components/Example/Form.tsx
@@ -4,13 +4,7 @@ import React from 'react'
 
 import { User } from '@phosphor-icons/react'
 
-import {
-  Input,
-  InputDescription,
-  InputLabel,
-  InputPasswordStrength,
-  InputRoot,
-} from '../shared'
+import { Input } from '../shared'
 
 export function FormExample() {
   const [password, setPassword] = React.useState('')
@@ -18,10 +12,10 @@ export function FormExample() {
 
   return (
     <div className="m-auto flex w-[496px] flex-col">
-      <InputRoot>
-        <InputLabel htmlFor="password">Senha</InputLabel>
+      <Input.Root>
+        <Input.Label htmlFor="password">Senha</Input.Label>
 
-        <Input
+        <Input.Input
           id="password"
           type="password"
           placeholder="Digite sua senha"
@@ -30,17 +24,17 @@ export function FormExample() {
           onChange={(e) => setPassword(e.target.value)}
         />
 
-        <InputPasswordStrength value={password} />
+        <Input.PasswordStrength value={password} />
 
-        <InputDescription>
+        <Input.Description>
           A senha deve ter pelo menos 8 caracteres, incluindo letras maiúsculas,
           minúsculas, números e caracteres especiais.
-        </InputDescription>
-      </InputRoot>
+        </Input.Description>
+      </Input.Root>
 
-      <InputRoot>
-        <InputLabel htmlFor="username">Nome de usuário</InputLabel>
-        <Input
+      <Input.Root>
+        <Input.Label htmlFor="username">Nome de usuário</Input.Label>
+        <Input.Input
           id="username"
           placeholder="Digite seu nome de usuário"
           icon={<User className="text-muted-foreground h-4 w-4" />}
@@ -48,10 +42,10 @@ export function FormExample() {
           value={username}
           onChange={(e) => setUsername(e.target.value)}
         />
-        <InputDescription>
+        <Input.Description>
           Seu nome de usuário será visível para outros usuários.
-        </InputDescription>
-      </InputRoot>
+        </Input.Description>
+      </Input.Root>
     </div>
   )
 }

--- a/src/presentation/components/shared/Input/Description.tsx
+++ b/src/presentation/components/shared/Input/Description.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-export interface InputDescriptionProps
+interface InputDescriptionProps
   extends React.HTMLAttributes<HTMLParagraphElement> {}
 
 export const InputDescription = React.forwardRef<

--- a/src/presentation/components/shared/Input/Description.tsx
+++ b/src/presentation/components/shared/Input/Description.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+export interface InputDescriptionProps
+  extends React.HTMLAttributes<HTMLParagraphElement> {}
+
+export const InputDescription = React.forwardRef<
+  HTMLParagraphElement,
+  InputDescriptionProps
+>(({ ...props }, ref) => {
+  return <p ref={ref} className="text-xs text-gray-400" {...props} />
+})
+InputDescription.displayName = 'InputDescription'

--- a/src/presentation/components/shared/Input/Field.tsx
+++ b/src/presentation/components/shared/Input/Field.tsx
@@ -6,13 +6,12 @@ import { Eye, EyeSlash } from '@phosphor-icons/react'
 
 import { condicionalStyles } from '@/presentation/helpers'
 
-export interface InputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {
+interface InputFieldProps extends React.InputHTMLAttributes<HTMLInputElement> {
   icon?: React.ReactNode
   iconPosition?: 'left' | 'right'
 }
 
-export const Input = React.forwardRef<HTMLInputElement, InputProps>(
+export const InputField = React.forwardRef<HTMLInputElement, InputFieldProps>(
   ({ type, icon, iconPosition = 'right', ...props }, ref) => {
     const [showPassword, setShowPassword] = React.useState(false)
     const isPassword = type === 'password'
@@ -60,4 +59,4 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
     )
   },
 )
-Input.displayName = 'Input'
+InputField.displayName = 'InputField'

--- a/src/presentation/components/shared/Input/Input.tsx
+++ b/src/presentation/components/shared/Input/Input.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import React from 'react'
+
+import { Eye, EyeSlash } from '@phosphor-icons/react'
+
+import { condicionalStyles } from '@/presentation/helpers'
+
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {
+  icon?: React.ReactNode
+  iconPosition?: 'left' | 'right'
+}
+
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ type, icon, iconPosition = 'right', ...props }, ref) => {
+    const [showPassword, setShowPassword] = React.useState(false)
+    const isPassword = type === 'password'
+
+    function togglePassword() {
+      setShowPassword((prev) => !prev)
+    }
+
+    return (
+      <div className="relative">
+        {icon && iconPosition === 'left' && (
+          <div className="absolute top-1/2 left-3 -translate-y-1/2">{icon}</div>
+        )}
+
+        <input
+          type={isPassword && showPassword ? 'text' : type}
+          className={condicionalStyles(
+            'bg-background flex w-full rounded-sm border border-gray-200 px-5 py-4 text-sm text-gray-500 placeholder:text-gray-300 focus-visible:ring-1 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50',
+            {
+              'pl-10': !!(icon && iconPosition === 'left'),
+              'pr-10': (icon && iconPosition === 'right') || isPassword,
+            },
+          )}
+          ref={ref}
+          {...props}
+        />
+
+        {icon && iconPosition === 'right' && !isPassword && (
+          <div className="absolute top-1/2 right-3 -translate-y-1/2">
+            {icon}
+          </div>
+        )}
+
+        {isPassword && (
+          <button
+            type="button"
+            onClick={togglePassword}
+            className="hover:text-foreground absolute top-1/2 right-3 -translate-y-1/2 text-gray-500"
+            tabIndex={-1}
+          >
+            {showPassword ? <EyeSlash size={20} /> : <Eye size={20} />}
+          </button>
+        )}
+      </div>
+    )
+  },
+)
+Input.displayName = 'Input'

--- a/src/presentation/components/shared/Input/Label.tsx
+++ b/src/presentation/components/shared/Input/Label.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 
-export interface InputLabelProps
-  extends React.LabelHTMLAttributes<HTMLLabelElement> {
+interface InputLabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {
   required?: boolean
 }
 

--- a/src/presentation/components/shared/Input/Label.tsx
+++ b/src/presentation/components/shared/Input/Label.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+
+export interface InputLabelProps
+  extends React.LabelHTMLAttributes<HTMLLabelElement> {
+  required?: boolean
+}
+
+export const InputLabel = React.forwardRef<HTMLLabelElement, InputLabelProps>(
+  ({ children, ...props }, ref) => {
+    return (
+      <label
+        ref={ref}
+        className="-tracking-(2px) text-sm font-medium text-gray-500 peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+        {...props}
+      >
+        {children}
+      </label>
+    )
+  },
+)
+InputLabel.displayName = 'InputLabel'

--- a/src/presentation/components/shared/Input/PasswordStrength.tsx
+++ b/src/presentation/components/shared/Input/PasswordStrength.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { condicionalStyles } from '@/presentation/helpers'
 
-export interface InputPasswordStrengthProps
+interface InputPasswordStrengthProps
   extends React.HTMLAttributes<HTMLDivElement> {
   value?: string
   minLength?: number

--- a/src/presentation/components/shared/Input/PasswordStrength.tsx
+++ b/src/presentation/components/shared/Input/PasswordStrength.tsx
@@ -1,0 +1,90 @@
+import React from 'react'
+
+import { condicionalStyles } from '@/presentation/helpers'
+
+export interface InputPasswordStrengthProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  value?: string
+  minLength?: number
+}
+
+export const InputPasswordStrength = React.forwardRef<
+  HTMLDivElement,
+  InputPasswordStrengthProps
+>(({ value = '', minLength = 8, ...props }, ref) => {
+  const strength = React.useMemo(() => {
+    if (!value) return 0
+
+    let score = 0
+
+    function checkLength(value: string) {
+      return value.length >= minLength
+    }
+
+    function checkUppercase(value: string) {
+      return /[A-Z]/.test(value)
+    }
+
+    function checkLowercaseAndNumber(value: string) {
+      return /[a-z]/.test(value) && /[0-9]/.test(value)
+    }
+
+    function checkSpecialChar(value: string) {
+      return /[^A-Za-z0-9]/.test(value)
+    }
+
+    if (checkLength(value)) score += 1
+    if (checkUppercase(value)) score += 1
+    if (checkLowercaseAndNumber(value)) score += 1
+    if (checkSpecialChar(value)) score += 1
+
+    return score
+  }, [value, minLength])
+
+  function getStrengthText() {
+    const strengthTexts: Record<number, string> = {
+      0: 'Muito fraca',
+      1: 'Fraca',
+      2: 'Média',
+      3: 'Boa',
+      4: 'Forte',
+    }
+
+    return strengthTexts[strength]
+  }
+
+  return (
+    <div ref={ref} className="flex items-center gap-5" {...props}>
+      <div className="flex h-1 w-full gap-3">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <div
+            key={index}
+            className={condicionalStyles(
+              'h-full flex-1 rounded-full transition-colors',
+              {
+                'bg-gray-200': index >= strength,
+                'bg-error-500': index < strength && strength === 1,
+                'bg-warning-500': index < strength && strength === 2,
+                'bg-warning-300': index < strength && strength === 3,
+                'bg-success-600': index < strength && strength === 4,
+              },
+            )}
+          />
+        ))}
+      </div>
+
+      <p
+        className={condicionalStyles('text-xs whitespace-nowrap', {
+          'text-gray-400': strength < 1,
+          'text-error-500': strength === 1,
+          'text-warning-500': strength === 2,
+          'text-warning-300': strength === 3,
+          'text-success-600': strength === 4,
+        })}
+      >
+        {getStrengthText()}
+      </p>
+    </div>
+  )
+})
+InputPasswordStrength.displayName = 'InputPasswordStrength'

--- a/src/presentation/components/shared/Input/Root.tsx
+++ b/src/presentation/components/shared/Input/Root.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-export interface InputRootProps extends React.HTMLAttributes<HTMLDivElement> {}
+interface InputRootProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 export const InputRoot = React.forwardRef<HTMLDivElement, InputRootProps>(
   ({ ...props }, ref) => {

--- a/src/presentation/components/shared/Input/Root.tsx
+++ b/src/presentation/components/shared/Input/Root.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+
+export interface InputRootProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export const InputRoot = React.forwardRef<HTMLDivElement, InputRootProps>(
+  ({ ...props }, ref) => {
+    return <div ref={ref} className="flex flex-col gap-4" {...props} />
+  },
+)
+InputRoot.displayName = 'InputRoot'

--- a/src/presentation/components/shared/Input/index.tsx
+++ b/src/presentation/components/shared/Input/index.tsx
@@ -1,0 +1,5 @@
+export { Input } from './Input'
+export { InputLabel } from './Label'
+export { InputDescription } from './Description'
+export { InputPasswordStrength } from './PasswordStrength'
+export { InputRoot } from './Root'

--- a/src/presentation/components/shared/Input/index.tsx
+++ b/src/presentation/components/shared/Input/index.tsx
@@ -1,5 +1,13 @@
-export { Input } from './Input'
-export { InputLabel } from './Label'
-export { InputDescription } from './Description'
-export { InputPasswordStrength } from './PasswordStrength'
-export { InputRoot } from './Root'
+import { InputRoot } from './Root'
+import { InputPasswordStrength } from './PasswordStrength'
+import { InputLabel } from './Label'
+import { InputField } from './Field'
+import { InputDescription } from './Description'
+
+export const Input = {
+  Root: InputRoot,
+  Input: InputField,
+  Label: InputLabel,
+  Description: InputDescription,
+  PasswordStrength: InputPasswordStrength,
+}

--- a/src/presentation/components/shared/index.ts
+++ b/src/presentation/components/shared/index.ts
@@ -1,2 +1,3 @@
 export * from './Button'
 export * from './Logo'
+export * from './Input'


### PR DESCRIPTION
Este PR, contém um conjunto de componentes que formam o componente de **Input**, seguindo o padrão composição, garantindo flexibilidade, reutilização e melhor separação, deste componentes.

Componentes adicionados, dentro da pasta Input:
- **Root**: wrapper que organiza os elementos do input.
- **Label**: componente de label.
- **Description**: para mensagens auxiliares ou instruções.
- **Input**: campo de entrada em si, com suporte a ícones e visualização de senha.
- **PasswordStrength**: medidor visual e textual da força da senha.

Além disso, foi incluído um componente Form como exemplo prático de uso.